### PR TITLE
Delovanje na Binderju

### DIFF
--- a/install.R
+++ b/install.R
@@ -12,3 +12,5 @@
 #    "numDeriv",
 #    "rootSolve"
 #))
+
+install.packages("rvest", repos="https://cloud.r-project.org")

--- a/projekt.Rmd
+++ b/projekt.Rmd
@@ -7,7 +7,7 @@ output:
     includes:
       in_header: lib/styles.sty
     latex_engine: xelatex
-  runtime: shiny
+runtime: shiny
 ---
 
 ```{r setup, echo=FALSE, results='hide', message=FALSE, warning=FALSE}


### PR DESCRIPTION
Kot sta s @timotejvesel ugotovila v #3, se prvi in zadnji graf ne prikažeta na Binderju - razlog je v tem, da je tam nameščena popravljena različica knjižnice `rvest`, ki pa očitno pri tabeli s strani https://sl.wikipedia.org/wiki/Turizem_v_Sloveniji ne deluje pravilno. Glede na to, da pravilno delujeta tako trenutna objavljena kot trenutna razvojna različica knjižnice `rvest`, je tukaj popravek, ki poskrbi za namestitev trenutne različice `rvest` v sliko za Binder (same slike raje ne bom spreminjal, da ne bom s tem vplival na delovanje drugih projektov). [Tukaj](https://mybinder.org/v2/gh/jaanos/APPR-2020-21/Ziga-Gartner?urlpath=shiny/APPR-2020-21/projekt.Rmd) lahko vidiš, kako izgleda poganjanje na Binderju s tem popravkom.